### PR TITLE
fix: Prettier endOfLine for cross-platform CI

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -4,6 +4,7 @@
   "trailingComma": "all",
   "printWidth": 100,
   "tabWidth": 2,
+  "endOfLine": "auto",
   "plugins": ["prettier-plugin-tailwindcss", "@trivago/prettier-plugin-sort-imports"],
   "importOrder": ["^react", "^next", "^@", "^[a-z]", "^[./]"],
   "importOrderSeparation": true,


### PR DESCRIPTION
## Summary

CI 在 Linux 跑但開發在 Windows，行尾符號不同導致 Prettier check 失敗 13 個檔案。加上 `endOfLine: auto` 讓 Prettier 不管行尾差異。

## Type
- [x] Bug fix

## Checklist
- [x] Build passes (`npm run build`)
- [x] No new lint warnings
- [x] Tested locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)