### PR TITLE
fix: security hardening, AI config, and dependency updates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,27 @@
+# ── LINE Bot ──────────────────────────────────────────
+LINE_CHANNEL_SECRET=
+LINE_CHANNEL_ACCESS_TOKEN=
+
+# ── Supabase ─────────────────────────────────────────
+NEXT_PUBLIC_SUPABASE_URL=
+NEXT_PUBLIC_SUPABASE_ANON_KEY=
+
+# ── AI (Zeabur AI Hub / OpenAI-compatible) ───────────
+ZEABUR_AI_HUB_KEY=
+
+# AI Base URL (default: Zeabur AI Hub Tokyo endpoint)
+AI_BASE_URL=https://hnd1.aihub.zeabur.ai/v1
+
+# AI Model names (defaults shown; override to use different models)
+AI_MODEL=gemini-2.5-flash
+AI_MODEL_STRONG=gemini-2.5-pro
+AI_MODEL_FAILOVER=gemini-2.5-flash-lite
+AI_MODEL_CLASSIFIER=gemini-2.5-flash-lite
+AI_MODEL_SUMMARY=gemini-2.5-flash-lite
+
+# ── Admin ────────────────────────────────────────────
+ADMIN_USERNAME=
+ADMIN_PASSWORD=
+
+# ── LIFF ─────────────────────────────────────────────
+NEXT_PUBLIC_LIFF_ID=

--- a/.env.example
+++ b/.env.example
@@ -29,5 +29,8 @@ ADMIN_SECRET=
 # Set this same value in QStash dashboard as Authorization: Bearer header
 CRON_SECRET=
 
+# ── Vercel Preview Only ──────────────────────────────
+# GOOGLE_AI_API_KEY=            # Gemini free tier, for Vercel preview testing
+
 # ── LIFF ─────────────────────────────────────────────
 NEXT_PUBLIC_LIFF_ID=

--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,12 @@ AI_MODEL_SUMMARY=gemini-2.5-flash-lite
 # ── Admin ────────────────────────────────────────────
 ADMIN_USERNAME=
 ADMIN_PASSWORD=
+ADMIN_SECRET=
+
+# ── Cron (Upstash QStash) ───────────────────────────
+# Used to authenticate scheduled cron requests (e.g., weekly product sync)
+# Set this same value in QStash dashboard as Authorization: Bearer header
+CRON_SECRET=
 
 # ── LIFF ─────────────────────────────────────────────
 NEXT_PUBLIC_LIFF_ID=

--- a/.gitignore
+++ b/.gitignore
@@ -23,8 +23,9 @@ yarn-debug.log*
 yarn-error.log*
 
 # Local env files
-.env*.local
 .env
+.env.production
+.env*.local
 
 # Vercel
 .vercel

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ zeabur deploy --project-id 69d9080ee8ec40d5bceac2c7 --service-id 69d90817e8ec40d
 
 ## Environment Variables
 
-- **Zeabur (Production)**: `ZEABUR_AI_HUB_KEY`, `AI_BASE_URL`, `AI_MODEL`, `CRON_SECRET`
+- **Zeabur (Production)**: `ZEABUR_AI_HUB_KEY`, `AI_BASE_URL`, `AI_MODEL`, `AI_MODEL_*` series, `CRON_SECRET`
 - **Vercel (Preview)**: `GOOGLE_AI_API_KEY` (Gemini, for testing only)
 - **Both share**: LINE keys, Supabase keys, Admin keys, LIFF ID
 - **Full list**: See `.env.example`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,19 @@ zeabur deploy --project-id 69d9080ee8ec40d5bceac2c7 --service-id 69d90817e8ec40d
 - **Vercel**: `GOOGLE_AI_API_KEY` (Google Gemini)
 - Both share: LINE keys, Supabase keys, Admin keys, LIFF ID
 
+## Checklists
+
+### Pre-push
+
+- Verify `.gitignore` is properly configured before pushing
+- Never commit `.env.local` or any file containing secrets (API keys, tokens)
+- Run `npm run build` to confirm the project compiles
+
+### Version Release
+
+- Update the version number in `package.json`
+- Verify all environment variables are documented in `.env.example`
+
 ## Tech Stack
 
 - Next.js 16 (App Router) + TypeScript + Tailwind CSS v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,13 +2,13 @@
 
 ## Deployment
 
-This project is deployed on **two platforms simultaneously**:
-
-### Zeabur (Primary - VPS)
+### Zeabur (Production)
 
 - **URL**: https://antnest-chatbot-0410.zeabur.app
 - **VPS**: Tencent Cloud Tokyo (43.167.169.222), 2vCPU/2GB
-- **AI Model**: Zeabur AI Hub (GPT-4.1 family via OpenAI-compatible API)
+- **AI Model**: Zeabur AI Hub (configurable via `AI_MODEL` env var)
+- **LINE Webhook**: Points here — all real customer traffic goes through Zeabur
+- **Cron**: Product sync via Upstash QStash (every Monday 20:05 TST)
 - **Project ID**: `69d9080ee8ec40d5bceac2c7`
 - **Service ID**: `69d90817e8ec40d5bceac2ca`
 - **Env ID**: `69d9080e474db8a99d6de860`
@@ -20,16 +20,17 @@ cd C:\Users\stans\Projects\antnest-chatbot
 zeabur deploy --project-id 69d9080ee8ec40d5bceac2c7 --service-id 69d90817e8ec40d5bceac2ca --name antnest-chatbot
 ```
 
-### Vercel (Legacy)
+### Vercel (Preview/Staging)
 
 - **URL**: https://antnest-chatbot.vercel.app
-- **AI Model**: Google Gemini 2.5 Flash
-- **Auto-deploy**: push to `main` branch triggers build
+- **AI Model**: Google Gemini 2.5 Flash (free tier for testing)
+- **Auto-deploy**: push to `main` triggers build — use to verify changes before Zeabur deploy
+- **Role**: Preview only. Do NOT point LINE Webhook here. No cron jobs.
 
 ### Shared Infrastructure
 
 - Both deployments share the **same Supabase database** — admin changes apply to both
-- LINE Webhook can only point to one deployment at a time
+- LINE Webhook points to Zeabur only
 
 ## Git Workflow
 
@@ -42,9 +43,10 @@ zeabur deploy --project-id 69d9080ee8ec40d5bceac2c7 --service-id 69d90817e8ec40d
 
 ## Environment Variables
 
-- **Zeabur**: `ZEABUR_AI_HUB_KEY` (Zeabur AI Hub)
-- **Vercel**: `GOOGLE_AI_API_KEY` (Google Gemini)
-- Both share: LINE keys, Supabase keys, Admin keys, LIFF ID
+- **Zeabur (Production)**: `ZEABUR_AI_HUB_KEY`, `AI_BASE_URL`, `AI_MODEL`, `CRON_SECRET`
+- **Vercel (Preview)**: `GOOGLE_AI_API_KEY` (Gemini, for testing only)
+- **Both share**: LINE keys, Supabase keys, Admin keys, LIFF ID
+- **Full list**: See `.env.example`
 
 ## Checklists
 

--- a/data/product-cards.json
+++ b/data/product-cards.json
@@ -4,7 +4,7 @@
     "price": "NT$290 起",
     "originalPrice": "NT$390",
     "description": "招牌！馬斯卡彭奶霜 × 現萃咖啡 × 咖啡酒，濃香不膩",
-    "image": "https://antnest-chatbot.vercel.app/images/classic-tiramisu-plated.jpeg",
+    "image": "https://cdn.cybassets.com/media/W1siZiIsIjM0ODQ3L3Byb2R1Y3RzLzYzMjExODA3LzE3NzM2NTQxMjlfNGMyMmE0Njg1NGM0ZWMzMzY3OWMuanBlZyJdLFsicCIsInRodW1iIiwiNjAweDYwMCJdXQ.jpeg?sha=ac893c6555ef09bd",
     "url": "https://antnest.cyberbiz.co/products/classic-tiramisu",
     "badges": ["🏆 招牌", "🍷 含酒精"]
   },
@@ -13,7 +13,7 @@
     "price": "NT$300",
     "originalPrice": "NT$400",
     "description": "以牛奶取代咖啡與酒，奧利奧控最愛！大人小孩都適合",
-    "image": "https://antnest-chatbot.vercel.app/images/oreo-tiramisu-with-box.jpeg",
+    "image": "https://cdn.cybassets.com/media/W1siZiIsIjM0ODQ3L3Byb2R1Y3RzLzY0NDg1MTExLzE3NzM2NTQyMDZfYWRhZWNlZTI2YTYyMzE0YTFmMDIuanBlZyJdLFsicCIsInRodW1iIiwiNjAweDYwMCJdXQ.jpeg?sha=a44c8f510395bced",
     "url": "https://antnest.cyberbiz.co/products/oreo-tiramisu",
     "badges": ["✅ 無酒精", "🌱 蛋奶素"]
   },
@@ -22,7 +22,7 @@
     "price": "NT$379 起",
     "originalPrice": "NT$499",
     "description": "杜拜巧克力延伸系列！雙層結構，脆脆層 × 馬斯卡彭奶霜",
-    "image": "https://antnest-chatbot.vercel.app/images/classic-tiramisu-with-box.jpeg",
+    "image": "https://cdn.cybassets.com/media/W1siZiIsIjM0ODQ3L3Byb2R1Y3RzLzYzMjEyMjIzLzE3Njc3Njg1NjRfZDk5OGQ5MDkxZDYyYjY3ZDliODEuanBlZyJdLFsicCIsInRodW1iIiwiNjAweDYwMCJdXQ.jpeg?sha=d95daef901dcff09",
     "url": "https://antnest.cyberbiz.co/products/black-chocolate-tiramisu",
     "badges": ["✅ 無酒精", "🔥 人氣"]
   },

--- a/data/product-cards.json
+++ b/data/product-cards.json
@@ -4,7 +4,7 @@
     "price": "NT$290 起",
     "originalPrice": "NT$390",
     "description": "招牌！馬斯卡彭奶霜 × 現萃咖啡 × 咖啡酒，濃香不膩",
-    "image": "https://antnest-dessert.com/images/classic-tiramisu-plated.jpeg",
+    "image": "https://antnest-chatbot.vercel.app/images/classic-tiramisu-plated.jpeg",
     "url": "https://antnest.cyberbiz.co/products/classic-tiramisu",
     "badges": ["🏆 招牌", "🍷 含酒精"]
   },
@@ -13,7 +13,7 @@
     "price": "NT$300",
     "originalPrice": "NT$400",
     "description": "以牛奶取代咖啡與酒，奧利奧控最愛！大人小孩都適合",
-    "image": "https://antnest-dessert.com/images/oreo-tiramisu-with-box.jpeg",
+    "image": "https://antnest-chatbot.vercel.app/images/oreo-tiramisu-with-box.jpeg",
     "url": "https://antnest.cyberbiz.co/products/oreo-tiramisu",
     "badges": ["✅ 無酒精", "🌱 蛋奶素"]
   },
@@ -22,7 +22,7 @@
     "price": "NT$379 起",
     "originalPrice": "NT$499",
     "description": "杜拜巧克力延伸系列！雙層結構，脆脆層 × 馬斯卡彭奶霜",
-    "image": "https://antnest-dessert.com/images/classic-tiramisu-with-box.jpeg",
+    "image": "https://antnest-chatbot.vercel.app/images/classic-tiramisu-with-box.jpeg",
     "url": "https://antnest.cyberbiz.co/products/black-chocolate-tiramisu",
     "badges": ["✅ 無酒精", "🔥 人氣"]
   },

--- a/lib/ai-client.ts
+++ b/lib/ai-client.ts
@@ -29,12 +29,12 @@ export interface ClassificationResult {
 }
 
 export const MODEL_DEFAULTS = {
-  classifier_model: 'gemini-2.5-flash-lite',
-  ai_model: 'gemini-2.5-flash',
-  strong_ai_model: 'gemini-2.5-pro',
-  failover_model: 'gemini-2.5-flash-lite',
-  summary_model: 'gemini-2.5-flash-lite',
-} as const;
+  classifier_model: process.env.AI_MODEL_CLASSIFIER || 'gemini-2.5-flash-lite',
+  ai_model: process.env.AI_MODEL || 'gemini-2.5-flash',
+  strong_ai_model: process.env.AI_MODEL_STRONG || 'gemini-2.5-pro',
+  failover_model: process.env.AI_MODEL_FAILOVER || 'gemini-2.5-flash-lite',
+  summary_model: process.env.AI_MODEL_SUMMARY || 'gemini-2.5-flash-lite',
+};
 
 export const STRONG_MODEL_DEFAULT = MODEL_DEFAULTS.strong_ai_model;
 
@@ -46,7 +46,7 @@ function getAIClient() {
     );
   }
   return new OpenAI({
-    baseURL: 'https://hnd1.aihub.zeabur.ai/v1',
+    baseURL: process.env.AI_BASE_URL || 'https://hnd1.aihub.zeabur.ai/v1',
     apiKey,
   });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2079,9 +2079,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.1.6.tgz",
-      "integrity": "sha512-N1ySLuZjnAtN3kFnwhAwPvZah8RJxKasD7x1f8shFqhncnWZn4JMfg37diLNuoHsLAlrDfM3g4mawVdtAG8XLQ==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.3.tgz",
+      "integrity": "sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -2095,9 +2095,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.6.tgz",
-      "integrity": "sha512-wTzYulosJr/6nFnqGW7FrG3jfUUlEf8UjGA0/pyypJl42ExdVgC6xJgcXQ+V8QFn6niSG2Pb8+MIG1mZr2vczw==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.3.tgz",
+      "integrity": "sha512-u37KDKTKQ+OQLvY+z7SNXixwo4Q2/IAJFDzU1fYe66IbCE51aDSAzkNDkWmLN0yjTUh4BKBd+hb69jYn6qqqSg==",
       "cpu": [
         "arm64"
       ],
@@ -2111,9 +2111,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.6.tgz",
-      "integrity": "sha512-BLFPYPDO+MNJsiDWbeVzqvYd4NyuRrEYVB5k2N3JfWncuHAy2IVwMAOlVQDFjj+krkWzhY2apvmekMkfQR0CUQ==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.3.tgz",
+      "integrity": "sha512-gHjL/qy6Q6CG3176FWbAKyKh9IfntKZTB3RY/YOJdDFpHGsUDXVH38U4mMNpHVGXmeYW4wj22dMp1lTfmu/bTQ==",
       "cpu": [
         "x64"
       ],
@@ -2127,9 +2127,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.6.tgz",
-      "integrity": "sha512-OJYkCd5pj/QloBvoEcJ2XiMnlJkRv9idWA/j0ugSuA34gMT6f5b7vOiCQHVRpvStoZUknhl6/UxOXL4OwtdaBw==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.3.tgz",
+      "integrity": "sha512-U6vtblPtU/P14Y/b/n9ZY0GOxbbIhTFuaFR7F4/uMBidCi2nSdaOFhA0Go81L61Zd6527+yvuX44T4ksnf8T+Q==",
       "cpu": [
         "arm64"
       ],
@@ -2143,9 +2143,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.6.tgz",
-      "integrity": "sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.3.tgz",
+      "integrity": "sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw==",
       "cpu": [
         "arm64"
       ],
@@ -2159,9 +2159,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.6.tgz",
-      "integrity": "sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.3.tgz",
+      "integrity": "sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ==",
       "cpu": [
         "x64"
       ],
@@ -2175,9 +2175,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.6.tgz",
-      "integrity": "sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.3.tgz",
+      "integrity": "sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw==",
       "cpu": [
         "x64"
       ],
@@ -2191,9 +2191,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.6.tgz",
-      "integrity": "sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.3.tgz",
+      "integrity": "sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw==",
       "cpu": [
         "arm64"
       ],
@@ -2207,9 +2207,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.6.tgz",
-      "integrity": "sha512-NRfO39AIrzBnixKbjuo2YiYhB6o9d8v/ymU9m/Xk8cyVk+k7XylniXkHwjs4s70wedVffc6bQNbufk5v0xEm0A==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.3.tgz",
+      "integrity": "sha512-Ibm29/GgB/ab5n7XKqlStkm54qqZE8v2FnijUPBgrd67FWrac45o/RsNlaOWjme/B5UqeWt/8KM4aWBwA1D2Kw==",
       "cpu": [
         "x64"
       ],
@@ -5395,15 +5395,25 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/axobject-query": {
@@ -8374,9 +8384,9 @@
       }
     },
     "node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "dev": true,
       "license": "MIT"
     },
@@ -8639,14 +8649,14 @@
       "peer": true
     },
     "node_modules/next": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.1.6.tgz",
-      "integrity": "sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.3.tgz",
+      "integrity": "sha512-9V3zV4oZFza3PVev5/poB9g0dEafVcgNyQ8eTRop8GvxZjV2G15FC5ARuG1eFD42QgeYkzJBJzHghNP8Ad9xtA==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.1.6",
+        "@next/env": "16.2.3",
         "@swc/helpers": "0.5.15",
-        "baseline-browser-mapping": "^2.8.3",
+        "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
         "styled-jsx": "5.1.6"
@@ -8658,15 +8668,15 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.1.6",
-        "@next/swc-darwin-x64": "16.1.6",
-        "@next/swc-linux-arm64-gnu": "16.1.6",
-        "@next/swc-linux-arm64-musl": "16.1.6",
-        "@next/swc-linux-x64-gnu": "16.1.6",
-        "@next/swc-linux-x64-musl": "16.1.6",
-        "@next/swc-win32-arm64-msvc": "16.1.6",
-        "@next/swc-win32-x64-msvc": "16.1.6",
-        "sharp": "^0.34.4"
+        "@next/swc-darwin-arm64": "16.2.3",
+        "@next/swc-darwin-x64": "16.2.3",
+        "@next/swc-linux-arm64-gnu": "16.2.3",
+        "@next/swc-linux-arm64-musl": "16.2.3",
+        "@next/swc-linux-x64-gnu": "16.2.3",
+        "@next/swc-linux-x64-musl": "16.2.3",
+        "@next/swc-win32-arm64-msvc": "16.2.3",
+        "@next/swc-win32-x64-msvc": "16.2.3",
+        "sharp": "^0.34.5"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",


### PR DESCRIPTION
## Summary
- `.gitignore` 補強（確保 `.env.production` 等被排除）
- `CLAUDE.md` 新增 Pre-push / Version Release checklist
- 3 個產品圖片 URL 還原至 `antnest-chatbot.vercel.app`（暫時性，後續會統一改為 Cyberbiz CDN）
- AI 模型設定全面環境變數化（`AI_BASE_URL`、`AI_MODEL` 等 5 個）
- 新建 `.env.example` 列出所有環境變數
- `npm audit fix` 修復 3 個漏洞（0 remaining）

## Test plan
- [ ] `npm run build` 通過
- [ ] LINE chatbot 正常回應
- [ ] 確認 AI 模型環境變數在 Zeabur 上正確設定

🤖 Generated with [Claude Code](https://claude.com/claude-code)